### PR TITLE
Make ordering of fields irrelevant

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,8 +13,8 @@ data Values = Values
   } deriving (Generic, Show)
 
 data Functions = Functions
-  { a :: Int -> Int
-  , b :: String -> String
+  { b :: String -> String
+  , a :: Int -> Int
   } deriving (Generic)
 
 values :: Values


### PR DESCRIPTION
The current approach requires the fields of the records to be in the same order.
I fixed this by sorting the lists before walking them